### PR TITLE
Refactor and used generic classes for GPT and T5 

### DIFF
--- a/mwp/dataset/dataset.py
+++ b/mwp/dataset/dataset.py
@@ -59,7 +59,7 @@ class MWPDataset(Dataset):
         vocabulary = [word for word, count in vocabulary.items() if count >= min_count]
         return vocabulary
 
-    def get_batch(self, index, batch_size) -> tuple[
+    def get_batch(self, index: int, batch_size: int) -> tuple[
         list[str], list[str], list[list[float]], list[int], list[int], list[Tensor]]:
         """
         This function returns a batch of the dataset.
@@ -102,7 +102,7 @@ class MWPDataset(Dataset):
             labels.append(torch.tensor(current_label))
         return labels
 
-    def load(self, path):
+    def load(self, path: str):
         """
         This function loads the dataset from the given path.
         Args:
@@ -145,13 +145,14 @@ class MWPDataset(Dataset):
         self.operator_labels = list()
         self.vocabulary = list()
 
-    def shuffle(self):
+    def shuffle(self, seed: int = 42):
         """
         This function shuffles the dataset.
 
         """
         zipped = list(
             zip(self.mwps, self.equations, self.operands, self.num_equations, self.num_operands, self.operator_labels))
+        random.seed(seed)
         random.shuffle(zipped)
         self.mwps, self.equations, self.operands, self.num_equations, self.num_operands, self.operator_labels = zip(
             *zipped)

--- a/mwp/model/context_selector/keybert_selector.py
+++ b/mwp/model/context_selector/keybert_selector.py
@@ -5,20 +5,20 @@ from sentence_transformers import SentenceTransformer
 
 from mwp.model.core.context_selector import ContextSelector
 
-random.seed(42)
-
 
 class KeyBERTContextSelector(ContextSelector):
     """
     This class implements the KeyBERT context selector.
     """
 
-    def __init__(self, model_path: str = "all-MiniLM-L6-v2", device: str = "cuda"):
+    def __init__(self, model_path: str = "all-MiniLM-L6-v2", device: str = "cuda", seed: int = 42):
         super(KeyBERTContextSelector, self).__init__()
         self.model_path = model_path
         self.device = device
         self.model = SentenceTransformer(self.model_path).to(self.device)
         self.keybert = KeyBERT(model=self.model)
+        self.seed = seed
+        random.seed(self.seed)
 
     def get_keywords(self, mwps: list[str], ngram_range: tuple[int, int] = (1, 2), top_n: int = 6) -> \
             tuple[None, None] | tuple[list[str] | None, None]:

--- a/mwp/model/context_selector/wang2021_selector.py
+++ b/mwp/model/context_selector/wang2021_selector.py
@@ -16,8 +16,8 @@ from mwp.model.core.context_selector import ContextSelector
 class WangContextSelector(ContextSelector):
     """
     This class implements the Context Selector proposed in
-    "Math Word Problem Generation with Mathematical Consistency and Problem Context Constraints"
-    by Wang et al. (2021)
+    "Math Word Problem Generation with Mathematical Consistency and Problem Context Constraints" by Wang et al. (2021)
+    https://aclanthology.org/2021.emnlp-main.484/
     """
 
     def __init__(

--- a/mwp/model/core/__init__.py
+++ b/mwp/model/core/__init__.py
@@ -1,4 +1,4 @@
 from .context_selector import ContextSelector, ContextSelectorOutput
 from .language_model import LanguageModel, LanguageModelOutput
-from .solvability_checker import SolvabilityChecker, SolvabilityCheckerOutput
 from .mwp import MWP, MWPOutput
+from .solvability_checker import SolvabilityChecker, SolvabilityCheckerOutput

--- a/mwp/model/core/mwp.py
+++ b/mwp/model/core/mwp.py
@@ -1,13 +1,14 @@
 from pathlib import Path
-from typing import Optional, Type
+from typing import Optional
 
 import torch
 import torch.nn as nn
 from torch import Tensor
 
 from .context_selector import ContextSelector, ContextSelectorOutput
-from .language_model import LanguageModel, LanguageModelOutput
+from .language_model import LanguageModelOutput
 from .solvability_checker import SolvabilityChecker, SolvabilityCheckerOutput
+from ..language_model import CausalLanguageModel, Seq2SeqLanguageModel
 
 
 class MWPOutput:
@@ -27,7 +28,7 @@ class MWP(nn.Module):
 
     def __init__(
             self,
-            language_model: Type[LanguageModel],
+            language_model: CausalLanguageModel | Seq2SeqLanguageModel,
             context_selector: Optional[ContextSelector] = None,
             solvability_checker: Optional[SolvabilityChecker] = None,
             device: str = "cuda"

--- a/mwp/model/core/solvability_checker.py
+++ b/mwp/model/core/solvability_checker.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from typing import Optional, Type
+from typing import Optional
 
 import torch
 import torch.nn.functional as F
 from torch import nn as nn, Tensor
 from transformers import AutoModel, AutoTokenizer
 
-from mwp.model.core import LanguageModel
+from mwp.model.language_model import CausalLanguageModel, Seq2SeqLanguageModel
 
 
 class SolvabilityCheckerOutput:
@@ -27,7 +27,7 @@ class SolvabilityChecker(nn.Module):
     def __init__(
             self,
             embedding_model_path: Optional[str] = "invokerliang/MWP-BERT-en",
-            language_model: Optional[Type[LanguageModel]] = None,
+            language_model: Optional[CausalLanguageModel | Seq2SeqLanguageModel] = None,
             device: str = "cuda"
     ):
         super(SolvabilityChecker, self).__init__()
@@ -143,7 +143,7 @@ class SolvabilityChecker(nn.Module):
             tokens: list[str],
             max_length: int = 256,
             average: bool = True
-    ):
+    ) -> Tensor:
         """
         Obtain the embedding of the tokens using the defined embedding model.
 

--- a/mwp/model/language_model/__init__.py
+++ b/mwp/model/language_model/__init__.py
@@ -1,2 +1,2 @@
-# from .gpt import GPTLanguageModel
-from .t5 import T5LanguageModel
+from .causal import CausalLanguageModel
+from .seq2seq import Seq2SeqLanguageModel

--- a/mwp/model/language_model/causal.py
+++ b/mwp/model/language_model/causal.py
@@ -1,20 +1,17 @@
 from typing import Optional
 
-from transformers import (
-    AutoModelForCausalLM,
-    AutoTokenizer,
-)
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from mwp.model.core.language_model import LanguageModel
 
 
-class GPTLanguageModel(LanguageModel):
+class CausalLanguageModel(LanguageModel):
     """
-    Implementation of GPT language models
+    Implementation of decoder-based Causal language models - GPT-2, GPT-Neo, GPT-J, etc.
     """
 
     def __init__(self, model_path: str, device: str = "cuda"):
-        super(GPTLanguageModel, self).__init__()
+        super(CausalLanguageModel, self).__init__()
         self.model_path = model_path
         self.device = device
         self.model = None
@@ -129,8 +126,8 @@ class GPTLanguageModel(LanguageModel):
 
         if generate_mode == "logits":
             output = self.forward_step(input_encoding)
-            generated_sequences = super(GPTLanguageModel).generate_from_logits(output.logits, prompt_lengths)
+            generated_sequences = super(CausalLanguageModel).generate_from_logits(output.logits, prompt_lengths)
         else:
-            generated_sequences = super(GPTLanguageModel).generate_by_sampling(input_encoding, prompt_lengths)
+            generated_sequences = super(CausalLanguageModel).generate_by_sampling(input_encoding, prompt_lengths)
 
         return generated_sequences

--- a/mwp/trainer/mwp.py
+++ b/mwp/trainer/mwp.py
@@ -134,10 +134,14 @@ class MWPTrainer(BaseTrainer):
                 self.optimizer.step()
                 steps += 1
                 num_batches += 1
+
             avg_epoch_loss = total_epoch_loss / num_batches
             self.scheduler.step(avg_epoch_loss)
-            print(f"Epoch {epoch} - Training Loss: {avg_epoch_loss}")
-            print(f"Epoch {epoch} completed. Current learning rate: {self.optimizer.param_groups[0]['lr']}")
+
+            print(f"Epoch {epoch} completed.\n"
+                  f"Training Loss: {avg_epoch_loss}\n"
+                  f"Current learning rate: {self.optimizer.param_groups[0]['lr']}"
+                  )
 
             self.push_training_state_to_hub(model, epoch, **kwargs)
             if epoch % kwargs.get("save_every", 1) == 0:

--- a/mwp/trainer/solvability.py
+++ b/mwp/trainer/solvability.py
@@ -81,8 +81,10 @@ class SolvabilityCheckerTrainer(BaseTrainer):
 
             avg_epoch_loss = total_epoch_loss / num_batches
             self.scheduler.step(avg_epoch_loss)
-            print(f"Epoch {epoch}, Training Loss: {avg_epoch_loss}")
-            print(f"Epoch {epoch} completed. Current learning rate: {self.optimizer.param_groups[0]['lr']}")
+
+            print(f"Epoch {epoch} completed.\n"
+                  f"Training Loss: {avg_epoch_loss}\n"
+                  f"Current learning rate: {self.optimizer.param_groups[0]['lr']}")
 
             self.push_training_state_to_hub(model, epoch, **kwargs)
             if epoch % kwargs.get("save_every", 1) == 0:

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -7,7 +7,7 @@ sys.path.insert(0, "./")
 import torch
 from mwp.dataset import MWPDataset
 from mwp.model.context_selector import KeyBERTContextSelector
-from mwp.model.language_model import T5LanguageModel
+from mwp.model.language_model import Seq2SeqLanguageModel
 from mwp.model.core.mwp import MWP
 from mwp.evaluator import LanguageModelEvaluator, SolvabilityEvaluator, DatasetOverlapEvaluator
 
@@ -18,7 +18,7 @@ dataset.load("data/processed/MAWPS.csv")
 # dataset.load("data/processed/PEN.csv")
 # dataset.shuffle()
 
-language_model = T5LanguageModel("google/flan-t5-base", device)
+language_model = Seq2SeqLanguageModel("google/flan-t5-base", device)
 context_selector = KeyBERTContextSelector(device=device)
 solvability_checker = SolvabilityChecker("invokerliang/MWP-BERT-en", language_model, device)
 solvability_checker.freeze()

--- a/src/train_mwpt5.py
+++ b/src/train_mwpt5.py
@@ -1,14 +1,12 @@
 import sys
 
-from mwp.model.language_model.gpt2 import GPTLanguageModel
-
 sys.path.insert(0, "./")
 
 import torch
 from mwp.dataset import MWPDataset
 from mwp.model.context_selector import KeyBERTContextSelector
 from mwp.model.core.solvability_checker import SolvabilityChecker
-from mwp.model.language_model import T5LanguageModel
+from mwp.model.language_model import Seq2SeqLanguageModel
 from mwp.model.core.mwp import MWP
 from mwp.trainer import MWPTrainer
 
@@ -19,12 +17,10 @@ dataset.load("data/processed/MAWPS.csv")
 # dataset.load("data/processed/PEN.csv")
 # dataset.shuffle()
 
-language_model = T5LanguageModel("google/flan-t5-base", device)
-# language_model = GPTLanguageModel("gpt2", device)
+language_model = Seq2SeqLanguageModel("google/flan-t5-base", device)
+# language_model = CausalLanguageModel("gpt2", device)
 context_selector = KeyBERTContextSelector(device=device)
-solvability_checker = SolvabilityChecker(
-    "invokerliang/MWP-BERT-en", language_model, device
-)
+solvability_checker = SolvabilityChecker("invokerliang/MWP-BERT-en", language_model, device)
 solvability_checker.freeze()
 model = MWP(language_model, context_selector, solvability_checker, device)
 


### PR DESCRIPTION
Refactored GPT and T5 implementations to now use generic classes:

* `T5LanguageModel` is now `Seq2SeqLanguageModel` => loads models using the `AutoModelForSeq2SeqLM` class
* `GPTLanguageModel` is now `CausalLanguageModel` => loads models using the `AutoModelForCausalLM` class

This will allow `Seq2SeqLanguageModel` to load not only T5-based models such as `google/flan-t5-base` (from the paper) but also other seq2seq approaches such as BART. Likewise, the `CausalLanguageModel` class now supports loading any GPT variant, Llama, Mistral, etc.

Corresponding changes have been made to the README and training scripts.